### PR TITLE
ignore cancelled kick events

### DIFF
--- a/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
@@ -110,7 +110,7 @@ public class CraftIRCListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerKick(PlayerKickEvent event) {
         if (this.plugin.isHeld(CraftIRC.HoldType.KICKS)) {
             return;


### PR DESCRIPTION
CraftIRC is incompatible with plugins such as Flight Clearance which cancel kick events.
This is an attempt to ignore those cancelled events as to prevent spam.
(This is also my very first patch for any Java project!)

See http://www.privatepaste.com/6467168f94 and http://www.privatepaste.com/bd1119a6dd for an extreme example, which went on for hours.
