### PR TITLE
Adjust priority of PlayerKickEvent to LOW

### DIFF
--- a/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
@@ -111,7 +111,7 @@ public class CraftIRCListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerKick(PlayerKickEvent event) {
         if (this.plugin.isHeld(CraftIRC.HoldType.KICKS)) {
             return;


### PR DESCRIPTION
If priority = EventPriority.MONITOR, we get precedence and end up not ignoring events cancelled by other plugins.

This is yet another attempt to improve compatibility with Flight Clearance.
