### PR TITLE
onPlayerCommandPreprocess Ignore Cancelled Events

### DIFF
--- a/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
@@ -14,7 +14,7 @@ public class CraftIRCListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
         try {
             final String[] split = event.getMessage().split(" ");


### PR DESCRIPTION
I've made a simple one line change to make onPlayerCommandPreprocess ignore cancelled events.  This is needed for a plugin I've been working on, mcMMOIRC.  It implements /me into the chats (admin and party) that do not need to be relayed to the main Minecraft EndPoint.
