### PR TITLE
Parts of maven updates from master branch. This one is meant to be pulle...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,14 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>[1.2.4-R0.1-SNAPSHOT,)</version>
+      <version>[1.2.3-R0.2,)</version>
       <type>jar</type>
     </dependency>
     <!-- You need to locally install this, there is no known repo -->
     <dependency>
       <groupId>net.milkbowl.vault</groupId>
       <artifactId>Vault</artifactId>
-      <version>[1.2.9-SNAPSHOT,)</version>
+      <version>[1.2.9,)</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
...d. See http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution for what the brackets do.

(This also changes the version tag to 3.6.0-SNAPSHOT as 3.5 is tagged.)
