### PR TITLE
Use getNick() in Minebot instead of this.nickname

### DIFF
--- a/src/com/ensifera/animosity/craftirc/CraftIRC.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRC.java
@@ -691,6 +691,9 @@ public class CraftIRC extends JavaPlugin {
             destinations = new LinkedList<EndPoint>();
             for (final String targetTag : this.cPathsFrom(sourceTag)) {
                 final EndPoint ep = this.getEndPoint(targetTag);
+                if (ep == null) {
+                    continue;
+                }
                 if ((ep instanceof SecuredEndPoint) && SecuredEndPoint.Security.REQUIRE_TARGET.equals(((SecuredEndPoint) ep).getSecurity())) {
                     continue;
                 }
@@ -705,6 +708,9 @@ public class CraftIRC extends JavaPlugin {
             //Default paths to unsecured destinations (auto-paths)
             if (this.cAutoPaths()) {
                 for (final EndPoint ep : this.endpoints.values()) {
+                    if (ep == null) {
+                        continue;
+                    }
                     if (msg.getSource().equals(ep) || destinations.contains(ep)) {
                         continue;
                     }

--- a/src/com/ensifera/animosity/craftirc/Minebot.java
+++ b/src/com/ensifera/animosity/craftirc/Minebot.java
@@ -240,7 +240,7 @@ public class Minebot extends PircBot implements Runnable {
     @Override
     public void onJoin(String channel, String sender, String login, String hostname) {
         if (this.channels.containsKey(channel)) {
-            if (sender.equals(this.nickname)) {
+            if (sender.equals(this.getNick())) {
                 this.amNowInChannel(channel);
             } else {
                 if (this.plugin.cUseMapAsWhitelist(this.botId) && !this.plugin.cNicknameIsInIrcMap(this.botId, sender)) {
@@ -272,7 +272,7 @@ public class Minebot extends PircBot implements Runnable {
 
     @Override
     public void onPart(String channel, String sender, String login, String hostname, String reason) {
-        if (sender.equals(this.nickname)) {
+        if (sender.equals(this.getNick())) {
             this.noLongerInChannel(channel, true);
         }
         if (this.channels.containsKey(channel)) {
@@ -298,7 +298,7 @@ public class Minebot extends PircBot implements Runnable {
 
     @Override
     public void onChannelQuit(String channel, String sender, String login, String hostname, String reason) {
-        if (sender.equals(this.nickname)) {
+        if (sender.equals(this.getNick())) {
             this.noLongerInChannel(channel, false);
         }
         if (this.channels.containsKey(channel)) {
@@ -324,7 +324,7 @@ public class Minebot extends PircBot implements Runnable {
 
     @Override
     public void onKick(String channel, String kickerNick, String kickerLogin, String kickerHostname, String recipientNick, String reason) {
-        if (recipientNick.equals(this.nickname)) {
+        if (recipientNick.equals(this.getNick())) {
             this.noLongerInChannel(channel, true);
         }
         if (this.channels.containsKey(channel)) {
@@ -356,7 +356,7 @@ public class Minebot extends PircBot implements Runnable {
 
     @Override
     public void onChannelNickChange(String channel, String oldNick, String login, String hostname, String newNick) {
-        if (oldNick.equals(this.nickname)) {
+        if (oldNick.equals(this.getNick())) {
             this.nickname = newNick;
         }
         if (this.channels.containsKey(channel)) {


### PR DESCRIPTION
The former is updated on every nick change, including those done by the
server.

This fixes a bug where the bot has nick "nick" defined, but it was
already used on login and the bot switches to "nick2". On every
PART/QUIT/KICK event by "nick" was interpreted as craftirc leaving the
channel.

Also changed delivery() to check if an EndPoint is null before adding it
to the destination list (This caused a null pointer exception before the
main bug was fixed)
