### PR TITLE
Initial '/' Breaks Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Eclipse stuff
-/.classpath
-/.project
-/.settings
-/.checkstyle
+.classpath
+.project
+.settings
+.checkstyle
 
 # netbeans
 /nbproject


### PR DESCRIPTION
This .gitignore is no good for the Egit plugin.
Does /.project work for any git version??
If it does, then instead add these lines without the /
Replaces #17
