### PR TITLE
Colour

### DIFF
--- a/src/com/ensifera/animosity/craftirc/CraftIRC.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRC.java
@@ -872,7 +872,7 @@ public class CraftIRC extends JavaPlugin {
         final Pattern color_codes = Pattern.compile(ChatColor.COLOR_CHAR + "[0-9a-f]");
         Matcher find_colors = color_codes.matcher(name);
         while (find_colors.find()) {
-            name = find_colors.replaceFirst(Character.toString((char) 3) + String.format("%02d", this.cColorIrcFromGame(find_colors.group())));
+            name = find_colors.replaceFirst(Character.toString((char) 3) + this.cColorIrcFromGame(find_colors.group()));
             find_colors = color_codes.matcher(name);
         }
         return name;
@@ -1000,40 +1000,45 @@ public class CraftIRC extends JavaPlugin {
         return "";
     }
 
-    public int cColorIrcFromGame(String game) {
+    public String cColorIrcFromGame(String game) {
         ConfigurationNode color;
         final Iterator<ConfigurationNode> it = this.colormap.iterator();
         while (it.hasNext()) {
             color = it.next();
             if (color.getString("game").equals(game)) {
-                return color.getInt("irc", this.cColorIrcFromName("foreground"));
+            	//Forces sending two digit colour codes. 
+                return (color.getString("irc").length() == 1 ? "0" : "") + color.getString("irc", this.cColorIrcFromName("foreground"));
             }
         }
         return this.cColorIrcFromName("foreground");
     }
 
-    public int cColorIrcFromName(String name) {
+    public String cColorIrcFromName(String name) {
         ConfigurationNode color;
         final Iterator<ConfigurationNode> it = this.colormap.iterator();
         while (it.hasNext()) {
             color = it.next();
             if (color.getString("name").equalsIgnoreCase(name) && (color.getProperty("irc") != null)) {
-                return color.getInt("irc", 1);
+                return color.getString("irc", "01");
             }
         }
         if (name.equalsIgnoreCase("foreground")) {
-            return 1;
+            return "01";
         } else {
             return this.cColorIrcFromName("foreground");
         }
     }
 
-    public String cColorGameFromIrc(int irc) {
+    public String cColorGameFromIrc(String irc) {
+    	//Always convert to two digits.
+    	if (irc.length() == 1)
+    		irc = "0"+irc;
         ConfigurationNode color;
         final Iterator<ConfigurationNode> it = this.colormap.iterator();
         while (it.hasNext()) {
             color = it.next();
-            if (color.getInt("irc", -1) == irc) {
+            //Enforce two digit comparisons.
+            if (color.getString("irc", "").equals(irc) || "0".concat(color.getString("irc", "")).equals(irc)) {
                 return color.getString("game", this.cColorGameFromName("foreground"));
             }
         }

--- a/src/com/ensifera/animosity/craftirc/RelayedMessage.java
+++ b/src/com/ensifera/animosity/craftirc/RelayedMessage.java
@@ -178,7 +178,7 @@ public class RelayedMessage {
                 final Pattern color_codes = Pattern.compile("\u00A7([A-Fa-f0-9])?");
                 Matcher find_colors = color_codes.matcher(result);
                 while (find_colors.find()) {
-                    result = find_colors.replaceFirst("\u0003" + Integer.toString(this.plugin.cColorIrcFromGame("\u00A7" + find_colors.group(1))));
+                    result = find_colors.replaceFirst("\u0003" + this.plugin.cColorIrcFromGame("\u00A7" + find_colors.group(1)));
                     find_colors = color_codes.matcher(result);
                 }
             } else if ((realTarget.getType() != EndPoint.Type.MINECRAFT) || !colors) {
@@ -189,16 +189,16 @@ public class RelayedMessage {
         if (this.source.getType() == EndPoint.Type.IRC) {
             if ((realTarget.getType() == EndPoint.Type.MINECRAFT) && colors) {
                 result = result.replaceAll("(" + Character.toString((char) 2) + "|" + Character.toString((char) 22) + "|" + Character.toString((char) 31) + ")", "");
-                final Pattern color_codes = Pattern.compile(Character.toString((char) 3) + "([01]?[0-9])(,[0-9]{0,2})?");
+                final Pattern color_codes = Pattern.compile(Character.toString((char) 3) + "([0-9]{1,2})(,[0-9]{1,2})?");
                 Matcher find_colors = color_codes.matcher(result);
                 while (find_colors.find()) {
-                    result = find_colors.replaceFirst(this.plugin.cColorGameFromIrc(Integer.parseInt(find_colors.group(1))));
+                    result = find_colors.replaceFirst(this.plugin.cColorGameFromIrc(find_colors.group(1)));
                     find_colors = color_codes.matcher(result);
                 }
                 result = result.replaceAll(Character.toString((char) 15) + "|" + Character.toString((char) 3), this.plugin.cColorGameFromName("foreground"));
             } else if ((realTarget.getType() != EndPoint.Type.IRC) || !colors) {
                 //Strip colors
-                result = result.replaceAll("(" + Character.toString((char) 2) + "|" + Character.toString((char) 15) + "|" + Character.toString((char) 22) + Character.toString((char) 31) + "|" + Character.toString((char) 3) + "[0-9]{0,2}(,[0-9]{0,2})?)", "");
+                result = result.replaceAll("(" + Character.toString((char) 2) + "|" + Character.toString((char) 15) + "|" + Character.toString((char) 22) + Character.toString((char) 31) + "|" + Character.toString((char) 3) + "[0-9]{0,2}(,[0-9]{1,2})?)", "");
             }
         }
 


### PR DESCRIPTION
This request changes the following behaviour:
1. Forces IRC colour code comparisons as two digits.
2. Always sends two-digit colour codes to IRC.
3. Allows coloured sentences to start with a comma.
4. Strips invalid two-digit colour codes from IRC (e.g. 16-99) so IRC output matches Minecraft output.
