### PR TITLE
Enables /say to be forwarded to IRC.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -92,6 +92,7 @@ settings:
       nick: '[%srcChannel%] * %sender% is now known as %message%'
       generic: '%message%'
     from-plain:
+      say: '[Server] %message%'
     #======================================
     
     #==========Colorful formatting=========
@@ -115,6 +116,8 @@ settings:
     #  kick: '%grey%[%srcChannel%]%darkgreen% * %sender% was kicked by %ircModPrefix%%moderator%'
     #  nick: '%grey%[%srcChannel%]%darkgreen% * %sender% is now known as %message%'
     #  generic: '%grey%%message%'
+    #from-plain:
+    #  say: '%magenta%[Server] %message%'
     #======================================
 
 

--- a/src/com/ensifera/animosity/craftirc/ConsoleListener.java
+++ b/src/com/ensifera/animosity/craftirc/ConsoleListener.java
@@ -16,7 +16,7 @@ public class ConsoleListener implements Listener {
     public void onServerCommand(ServerCommandEvent event) {
         if (event.getCommand().toLowerCase().startsWith("say")) {
             final String message = event.getCommand().substring(4);
-            final RelayedMessage msg = this.plugin.newMsg(this.plugin.getEndPoint(this.plugin.cConsoleTag()), null, "console");
+            final RelayedMessage msg = this.plugin.newMsg(this.plugin.getEndPoint(this.plugin.cConsoleTag()), null, "say");
             msg.setField("message", message);
             msg.doNotColor("message");
             msg.post();

--- a/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
@@ -1,5 +1,6 @@
 package com.ensifera.animosity.craftirc;
 
+import org.bukkit.Server;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -30,6 +31,14 @@ public class CraftIRCListener implements Listener {
                 msg.setField("realSender", event.getPlayer().getName());
                 msg.setField("prefix", this.plugin.getPrefix(event.getPlayer()));
                 msg.setField("suffix", this.plugin.getSuffix(event.getPlayer()));
+                msg.doNotColor("message");
+                msg.post();
+            }
+            if (split[0].equalsIgnoreCase("/say")) {
+            	if (!(event.getPlayer().hasPermission("bukkit.command.say") && event.getPlayer().hasPermission(Server.BROADCAST_CHANNEL_USERS))) return;
+            	final String message = event.getMessage().substring(5);
+                final RelayedMessage msg = this.plugin.newMsg(this.plugin.getEndPoint(this.plugin.cMinecraftTag()), null, "say");
+                msg.setField("message", message);
                 msg.doNotColor("message");
                 msg.post();
             }


### PR DESCRIPTION
This change allows the /say command (from authorised users or from the console) to be forwarded to the attached IRC channel.

This allows a person accessing the console to talk to both IRC and minecraft with a single command.
It uses the `from-plain:` formatting map.
