### PR TITLE
Console /ircsay and /ircmsg tag now use the same sender name.

### DIFF
--- a/src/com/ensifera/animosity/craftirc/CraftIRC.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRC.java
@@ -381,7 +381,7 @@ public class CraftIRC extends JavaPlugin {
             if (sender instanceof Player) {
                 msg.setField("sender", ((Player) sender).getDisplayName());
             } else {
-                msg.setField("sender", "CONSOLE");
+                msg.setField("sender", sender.getName());
             }
             msg.setField("message", msgToSend);
             msg.doNotColor("message");


### PR DESCRIPTION
They both say `<CONSOLE>` instead of one saying `<SERVER>`.
