### PR TITLE
Console and commands

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -92,6 +92,8 @@ settings:
       nick: '[%srcChannel%] * %sender% is now known as %message%'
       generic: '%message%'
     from-plain:
+      action: '* %sender% %message%'
+      say: '[Server] %message%'
     #======================================
     
     #==========Colorful formatting=========
@@ -115,6 +117,9 @@ settings:
     #  kick: '%grey%[%srcChannel%]%darkgreen% * %sender% was kicked by %ircModPrefix%%moderator%'
     #  nick: '%grey%[%srcChannel%]%darkgreen% * %sender% is now known as %message%'
     #  generic: '%grey%%message%'
+    #from-plain:
+    #  action: '%purple%* %sender%%purple% %message%'
+    #  say: '%magenta%[Server] %message%'
     #======================================
 
 

--- a/src/com/ensifera/animosity/craftirc/ConsoleListener.java
+++ b/src/com/ensifera/animosity/craftirc/ConsoleListener.java
@@ -14,9 +14,22 @@ public class ConsoleListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onServerCommand(ServerCommandEvent event) {
-        if (event.getCommand().toLowerCase().startsWith("say")) {
-            final String message = event.getCommand().substring(4);
-            final RelayedMessage msg = this.plugin.newMsg(this.plugin.getEndPoint(this.plugin.cConsoleTag()), null, "console");
+        String message = null;
+        String eventType = null;
+        if (event.getCommand().toLowerCase().startsWith("say") && event.getCommand().length() > 4) {
+            message = event.getCommand().substring(4);
+            eventType = "say";
+        }
+        if (event.getCommand().toLowerCase().startsWith("me") && event.getCommand().length() > 3) {
+            message = event.getCommand().substring(3);
+            eventType = "action";
+        }
+        if (message != null) {
+            final RelayedMessage msg = this.plugin.newMsg(this.plugin.getEndPoint(this.plugin.cConsoleTag()), null, eventType);
+            if (msg == null) {
+                return;
+            }
+            msg.setField("sender", event.getSender().getName());
             msg.setField("message", message);
             msg.doNotColor("message");
             msg.post();

--- a/src/com/ensifera/animosity/craftirc/CraftIRC.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRC.java
@@ -381,7 +381,7 @@ public class CraftIRC extends JavaPlugin {
             if (sender instanceof Player) {
                 msg.setField("sender", ((Player) sender).getDisplayName());
             } else {
-                msg.setField("sender", "SERVER");
+                msg.setField("sender", sender.getName());
             }
             msg.setField("message", msgToSend);
             msg.doNotColor("message");
@@ -407,7 +407,7 @@ public class CraftIRC extends JavaPlugin {
             if (sender instanceof Player) {
                 msg.setField("sender", ((Player) sender).getDisplayName());
             } else {
-                msg.setField("sender", "SERVER");
+                msg.setField("sender", sender.getName());
             };
             msg.setField("message", msgToSend);
             msg.doNotColor("message");


### PR DESCRIPTION
- Allows the console to have 'say' and 'me' command results forwarded to IRC.
- Allows player '/say' to be forwarded to IRC.
- Prevents players using '/me' action if they do not have permission.
- Makes 'ircsay' and 'ircmsg' name results consistent for console.
