### PR TITLE
VanishNoPacket support.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,6 +2,7 @@ name: CraftIRC
 main: com.ensifera.animosity.craftirc.CraftIRC
 authors: [Animosity, Protected, mbaxter]
 version: '${project.version}'
+softdepend: ['VanishNoPacket']
 commands:
   ircsay:
     description: Relays message as from minecraft

--- a/src/com/ensifera/animosity/craftirc/CraftIRC.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRC.java
@@ -411,7 +411,14 @@ public class CraftIRC extends JavaPlugin {
             };
             msg.setField("message", msgToSend);
             msg.doNotColor("message");
-            msg.postToUser(args[1]);
+            boolean sameEndPoint = this.getEndPoint(this.cMinecraftTag()).equals(this.getEndPoint(args[0]));
+            //Don't actually deliver the message if the user is invisible to the sender.
+            if (sameEndPoint && sender instanceof Player) {
+                Player recipient = getServer().getPlayer(args[1]);
+                if (recipient != null && recipient.isOnline() && ((Player)sender).canSee(recipient))
+                    msg.postToUser(args[1]);
+            } else
+                msg.postToUser(args[1]);
             sender.sendMessage("Message sent.");
             return true;
         } catch (final Exception e) {

--- a/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
+++ b/src/com/ensifera/animosity/craftirc/CraftIRCListener.java
@@ -71,6 +71,9 @@ public class CraftIRCListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerJoin(PlayerJoinEvent event) {
+        if (this.plugin.getServer().getPluginManager().isPluginEnabled("VanishNoPacket") && event.getPlayer().hasPermission("vanish.joinwithoutannounce")) {
+            return;
+        }
         if (this.plugin.isHeld(CraftIRC.HoldType.JOINS)) {
             return;
         }
@@ -92,6 +95,9 @@ public class CraftIRCListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerQuit(PlayerQuitEvent event) {
+        if (this.plugin.getServer().getPluginManager().isPluginEnabled("VanishNoPacket") && event.getPlayer().hasPermission("vanish.silentquit")) {
+            return;
+        }
         if (this.plugin.isHeld(CraftIRC.HoldType.QUITS)) {
             return;
         }

--- a/src/com/ensifera/animosity/craftirc/MinecraftPoint.java
+++ b/src/com/ensifera/animosity/craftirc/MinecraftPoint.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
+import org.kitteh.vanish.staticaccess.VanishNoPacket;
 
 public class MinecraftPoint implements CommandEndPoint {
 
@@ -69,9 +70,17 @@ public class MinecraftPoint implements CommandEndPoint {
 
     @Override
     public List<String> listDisplayUsers() {
+        boolean isVanishEnabled = this.server.getPluginManager().isPluginEnabled("VanishNoPacket");
         final LinkedList<String> users = new LinkedList<String>();
         for (final Player p : this.server.getOnlinePlayers()) {
-            users.add(p.getDisplayName());
+            if (isVanishEnabled) {
+                try {
+                    if (!VanishNoPacket.isVanished(p.getName())) {
+                        users.add(p.getName());
+                    }
+                } catch (Exception e) {}
+            } else
+                users.add(p.getName());
         }
         Collections.sort(users);
         return users;


### PR DESCRIPTION
Removes vanished player from .players command, prevents sending joins and quits for those with the appropriate permissions and silently drops /ircmsguser messages sent.
