### PR TITLE
from-game %moderator% is never set

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -82,7 +82,7 @@ settings:
       action: '* %sender% %message%'
       join: '[%sender% connected]'
       quit: '[%sender% disconnected]'
-      kick: '[%moderator% KICKED %sender% (%message%)]'
+      kick: '[%sender% was KICKED (%message%)]'
       admin: '%sender% to online admins ->- %message%'
       generic: '%message%'
       death: '%message%'


### PR DESCRIPTION
`from-game` `%moderator%` is never set because it is not present in [PlayerKickEvent](http://jd.bukkit.org/apidocs/org/bukkit/event/player/PlayerKickEvent.html). The colourful formatting was already correct.
