### PR TITLE
Fixes nested continue only skipping the inner loop.

### DIFF
--- a/src/com/ensifera/animosity/craftirc/MinecraftPoint.java
+++ b/src/com/ensifera/animosity/craftirc/MinecraftPoint.java
@@ -72,11 +72,11 @@ public class MinecraftPoint implements CommandEndPoint {
     public List<String> listDisplayUsers() {
         boolean isVanishEnabled = this.server.getPluginManager().isPluginEnabled("VanishNoPacket");
         final LinkedList<String> users = new LinkedList<String>();
-        for (final Player p : this.server.getOnlinePlayers()) {
+        playerLoop: for (final Player p : this.server.getOnlinePlayers()) {
             if (isVanishEnabled) {
                 for (MetadataValue value : p.getMetadata("vanished")) {
                     if (value.getOwningPlugin().getName().equals("VanishNoPacket") && value.asBoolean()) {
-                        continue;
+                        continue playerLoop;
                     }
                 }
                 


### PR DESCRIPTION
It doesn't skip adding hidden players to the list unless the continue moves to the next iteration of the **outer** for loop.

_So, is a barely known feature of the Java language preferable to a rewrite the loop logic here? :)_
