### PR TITLE
Use irc.example.com as the server in the example, instead of Esper.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -134,7 +134,7 @@ settings:
 bots:
 
   - nickname: 'CraftIRCbot'
-    server: 'irc.esper.net'
+    server: 'irc.example.com'
     port: 6667
     userident: 'bot'              #Username/ident, anything you want
     serverpass: ''                #This isn't the nickserv password


### PR DESCRIPTION
Too many unconfigured bots connect to Esper.  This commit changes the server in the config file to irc.example.com.
