### PR TITLE
Fix mode parsing on inspircd 3

### DIFF
--- a/src/main/java/com/ensifera/animosity/craftirc/libs/org/jibble/pircbot/PircBot.java
+++ b/src/main/java/com/ensifera/animosity/craftirc/libs/org/jibble/pircbot/PircBot.java
@@ -1554,6 +1554,12 @@ public abstract class PircBot implements ReplyConstants, PircBotLogger {
                 t++;
             }
 
+            // treat last param as a middle param
+            // section 2.3.1 of RFC 1459 
+            if (params[params.length - 1].startsWith(":")) {
+                params[params.length - 1] = params[params.length - 1].substring(1);
+            }
+
             char pn = ' ';
             int p = 1;
 


### PR DESCRIPTION
inspircd3 sends modes as:

`:Nick!user@host.example.com MODE #channel +o :TargetNick`

this pr removes the ` : ` before TargetNick if present